### PR TITLE
Unbind server port when calling shutdown!

### DIFF
--- a/test/net/async/test_tcp.clj
+++ b/test/net/async/test_tcp.clj
@@ -138,6 +138,19 @@
     (shutdown! host1)
     (shutdown! host2)))
 
+(deftest test-port-binding
+  (let [host0 (event-loop)
+        _ (accept host0 {:port 9791})
+        _ (shutdown! host0)
+        host1 (event-loop)
+        acceptor (try (accept host1 {:port 9791})
+                      :connected
+                      (catch java.net.BindException e
+                        :already-bound))]
+    (is (= :connected acceptor))
+
+    (shutdown! host1)))
+
 ;; SAMPLE ECHO SERVER
 ;; lein trampoline run -m net.async.test-tcp/test-server &
 ;; lein trampoline run -m net.async.test-tcp/test-client


### PR DESCRIPTION
When closing a SelectableChannel, the port isn't immediately unbound. The port is bound until the
channel's Selector runs a selection operation which triggers the deregistration of the
channel from the Selector.

See
https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/channels/Selector.html#selop

Here we only pass in the selector when we're shutting down the event loop because in
other cases we may spawn another channel to handle traffic from that port.

Fixes #4